### PR TITLE
Show detail

### DIFF
--- a/apps/task_app/static/js/index.js
+++ b/apps/task_app/static/js/index.js
@@ -24,7 +24,8 @@ let init = (app) => {
         tag_colors:[],
         selected_tag:null,
         users: [],
-        past_selected: []
+        past_selected: [],
+        display_asign:""
     };
 
     app.enumerate = (a) => {
@@ -74,6 +75,16 @@ let init = (app) => {
             default:
                 app.vue.mode = "table"
         }
+    };
+
+    app.show_detail = function(task){
+        app.vue.selected_task = task.id;
+        app.vue.task_name = task.name;
+        app.vue.task_description = task.description;
+        app.vue.task_deadline = task.deadline;
+        app.vue.form_sub_tag = task.tag;
+        app.vue.display_asign = task.assigned.join(", ");
+        app.switch_mode(5)
     };
 
     app.edit_mode = function(task){
@@ -248,7 +259,8 @@ let init = (app) => {
         assign_user: app.assign_user,
         tag_name_from_id: app.tag_name_from_id,
         tag_color_from_id: app.tag_color_from_id,
-        update: app.update
+        update: app.update,
+        show_detail: app.show_detail
     };
 
     // This creates the Vue instance.

--- a/apps/task_app/static/js/index.js
+++ b/apps/task_app/static/js/index.js
@@ -68,6 +68,9 @@ let init = (app) => {
             case 4:
                 app.vue.mode = "addtag"
                 break;
+            case 5:
+                app.vue.mode = "detail"
+                break;
             default:
                 app.vue.mode = "table"
         }

--- a/apps/task_app/templates/index.html
+++ b/apps/task_app/templates/index.html
@@ -176,7 +176,10 @@
                         <tbody v-for="untask in uncompleted_tasks">
                             <tr v-if="selected_tag == null || selected_tag == untask.tag">
                                 <td>{{untask.name}}</td>
-                                <td>{{untask.description}}</td>
+                                <td>
+                                    {{untask.description.slice(0,20)}}
+                                    <a v-if="untask.description.length > 20">... (detail)</a>
+                                </td>
                                 <td class="has-text-danger" v-if="untask.overdue">
                                     {{untask.timeleft}}
                                 </td>
@@ -219,7 +222,7 @@
                         <tbody v-for="task in completed_tasks">
                             <tr v-if="selected_tag == null || selected_tag == task.tag">
                                 <td>{{task.name}}</td>
-                                <td>{{task.description}}</td>
+                                <td>{{task.description.slice(0,20)}}</td>
                                 <td>
                                     {{task.assigned.join(", ")}}
                                 </td>

--- a/apps/task_app/templates/index.html
+++ b/apps/task_app/templates/index.html
@@ -137,6 +137,20 @@
                 </div>
             </div>
             
+            <!--show_detail-->
+            <div class="field" v-if="mode=='detail'">
+                <h1 class="title is-1">{{task_name}}</h1>
+                <p class="subtitle is-6"> <b>Tag:</b> {{tag_name_from_id(form_sub_tag)}}</p>
+                <textarea class="textarea" readonly>{{ task_description }}</textarea>
+                <p class="subtitle is-6"> <b>Asigned to: </b> {{display_asign}}</p>
+                <p class="title is-5">Deadline: {{task_deadline}}</p>
+                <a @click="switch_mode(1)">
+                    <button class="button">
+                        Back
+                    </button>
+                </a>
+            </div>
+
             <!--main page-->
             <div v-if="mode== 'table'">
                 <!--uncompleted_task_table-->
@@ -178,7 +192,7 @@
                                 <td>{{untask.name}}</td>
                                 <td>
                                     {{untask.description.slice(0,20)}}
-                                    <a v-if="untask.description.length > 20">... (detail)</a>
+                                    <a v-if="untask.description.length > 20" @click="show_detail(untask)">... (detail)</a>
                                 </td>
                                 <td class="has-text-danger" v-if="untask.overdue">
                                     {{untask.timeleft}}
@@ -222,7 +236,10 @@
                         <tbody v-for="task in completed_tasks">
                             <tr v-if="selected_tag == null || selected_tag == task.tag">
                                 <td>{{task.name}}</td>
-                                <td>{{task.description.slice(0,20)}}</td>
+                                <td>
+                                    {{task.description.slice(0,20)}}
+                                    <a v-if="task.description.length > 20" @click="show_detail(task)">... (detail)</a>
+                                </td>
                                 <td>
                                     {{task.assigned.join(", ")}}
                                 </td>


### PR DESCRIPTION
![Screenshot 2023-06-09 at 6 15 15 AM](https://github.com/nithins1/task-manager/assets/25620864/c35525f6-091f-4784-96a8-da3c2e1f5bb4)
![Screenshot 2023-06-09 at 6 15 21 AM](https://github.com/nithins1/task-manager/assets/25620864/67184d2b-0843-425f-88ed-a9a122392ed0)

Add detail view screen.
If the description length is over 20, then the detail button is created next to the description.
To go back, there is a back button.
The textarea is readonly, cannot edit, because the purpose of this page is just showing detail of task.
